### PR TITLE
fix: fix markdown for techniques data model table

### DIFF
--- a/data_model.md
+++ b/data_model.md
@@ -49,7 +49,7 @@ Most importantly, please do not include any information beyond that specified in
 
 ## Techniques
 
-| Field            | Datatype     | Description |
+| Field            | Datatype     | Description |                                                                                                                                                                                                                                                                                                                      |
 | ---------------- | ------------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **technique_id** | String       | yes         | The ATT&CK ID (e.g., "T1086") that was observed.                                                                                                                                                                                                                                                                     |
 | platform         | String       | no          | The platform this technique was observed on. Please include the full name, edition, and version. E.g., "Windows 10 Enterprise", "Windows Server 2012 Standard", "MacOS 10.13.5", "Ubuntu 14.04".                                                                                                                     |


### PR DESCRIPTION
## What Changed
- The markdown for the techniques data model table was incorrect so the table rendered as unformatted text instead of a table. This PR fixes the markdown.

## Known Limitations
None.

## Issue Screenshot
![image](https://user-images.githubusercontent.com/827774/165152947-1bdbf6bb-f1fc-4086-93f9-15cc3375d8bc.png)
